### PR TITLE
Add support for a prop that will only be server rendered

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,12 @@ export const renderReactWithAphrodite = (name, component) => hypernova({
         ReactDOMServer.renderToString(React.createElement(component, props))
       ));
 
+      // We don't want to serialize the serverOnlyData
+      const propsToSerialize = { ...props };
+      delete propsToSerialize.serverOnlyData;
+
       const style = `<style data-aphrodite>${css.content}</style>`;
-      const markup = serialize(name, html, props);
+      const markup = serialize(name, html, propsToSerialize);
       const classNames = toScript({ 'aphrodite-css': name }, css.renderedClassNames);
 
       return `${style}\n${markup}\n${classNames}`;


### PR DESCRIPTION
This PR handles passing serverOnlyData as a prop into the component. The idea here is that we want to be able to pass in data that only gets rendered on the server. For static components, we don't need the data client-side because the component doesn't need to rerender, so we can reduce the page size by only rendering the data on the server.

@goatslacker 