### PR TITLE
Update client render method to be compatible with Hypernova 2.0.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,11 +24,15 @@ export const renderReactWithAphrodite = (name, component) => hypernova({
     const classNames = fromScript({ 'aphrodite-css': name });
     if (classNames) StyleSheet.rehydrate(classNames);
 
-    const { node, data } = load(name);
-
-    if (node) {
-      const element = React.createElement(component, data);
-      ReactDOM.render(element, node);
+    const payloads = load(name);
+    if (payloads) {
+      payloads.forEach((payload) => {
+        const { node, data } = payload;
+        if (node) {
+          const element = React.createElement(component, data);
+          ReactDOM.render(element, node);
+        }
+      });
     }
 
     return component;


### PR DESCRIPTION
I changed the client render method to be compatible with Hypernova 2.0.0, which returns an array from the 'load' method as opposed to an object in previous versions.

@goatslacker 