### PR TITLE
Add static render function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ export const renderReactWithAphrodite = (name, component) => hypernova({
         ReactDOMServer.renderToString(React.createElement(component, props))
       ));
 
-      const style = `<style data-aphrodite>${css.content}</style>`;
+      const style = `<style data-aphrodite="data-aphrodite">${css.content}</style>`;
       const markup = serialize(name, html, props);
       const classNames = toScript({ 'aphrodite-css': name }, css.renderedClassNames);
 
@@ -45,7 +45,7 @@ export const renderReactWithAphroditeStatic = (name, component) => hypernova({
         ReactDOMServer.renderToStaticMarkup(React.createElement(component, props))
       ));
 
-      const style = `<style data-aphrodite>${css.content}</style>`;
+      const style = `<style data-aphrodite="data-aphrodite">${css.content}</style>`;
 
       return `${style}\n${html}`;
     };

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ import ReactDOMServer from 'react-dom/server';
 import hypernova, { serialize, load, toScript, fromScript } from 'hypernova';
 import { StyleSheet, StyleSheetServer } from 'aphrodite';
 
-/* eslint import/prefer-default-export: 1 */
 export const renderReactWithAphrodite = (name, component) => hypernova({
   server() {
     return (props) => {
@@ -37,4 +36,20 @@ export const renderReactWithAphrodite = (name, component) => hypernova({
 
     return component;
   },
+});
+
+export const renderReactWithAphroditeStatic = (name, component) => hypernova({
+  server() {
+    return (props) => {
+      const { html, css } = StyleSheetServer.renderStatic(() => (
+        ReactDOMServer.renderToStaticMarkup(React.createElement(component, props))
+      ));
+
+      const style = `<style data-aphrodite>${css.content}</style>`;
+
+      return `${style}\n${html}`;
+    };
+  },
+
+  client() {},
 });

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -4,13 +4,23 @@ import { assert } from 'chai';
 import AphroditeComponent from './components/AphroditeComponent';
 import { renderReactWithAphrodite, renderReactWithAphroditeStatic } from '../';
 
-describe('aphrodite css rendering', () => {
+describe('renderReactWithAphrodite aphrodite css rendering', () => {
+  let originalWindow;
+  let originalDocument;
   let result;
+
   beforeEach(() => {
+    originalWindow = global.window;
+    originalDocument = global.document;
     result = renderReactWithAphrodite('AC', AphroditeComponent)({
       children: ['Zack'],
       onPress() { console.log('Clicked'); },
     });
+  });
+
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
   });
 
   it('the markup looks good', () => {
@@ -38,39 +48,53 @@ describe('aphrodite css rendering', () => {
   });
 });
 
-describe('renderReactWithAphroditeStatic', () => {
+describe('renderReactWithAphroditeStatic static aphrodite css rendering', () => {
+  let originalWindow;
+  let originalDocument;
   let result;
+
   beforeEach(() => {
+    originalWindow = global.window;
+    originalDocument = global.document;
     result = renderReactWithAphroditeStatic('AC', AphroditeComponent)({
       children: ['Steven'],
-      onPress() { console.log('Clicked'); },
+      onPress() {},
     });
   });
 
-  it('the markup looks good', () => {
-    assert.isString(result);
-
-    assert.ok(/style data-aphrodite/.test(result));
-    assert.ok(/Steven/.test(result));
+  afterEach(() => {
+    global.window = originalWindow;
+    global.document = originalDocument;
   });
 
-  it('the markup does not contain aphrodite-css info for the client', () => {
-    assert.isFalse(/data-aphrodite-css/.test(result));
+  describe('on the server', () => {
+    it('the output contains styles and component content', () => {
+      assert.isString(result);
+
+      assert.ok(/style data-aphrodite/.test(result));
+      assert.ok(/Steven/.test(result));
+    });
+
+    it('the markup does not contain aphrodite-css info for the client', () => {
+      assert.isFalse(/data-aphrodite-css/.test(result));
+    });
   });
 
-  it('returns nothing when used on the client', (done) => {
-    jsdom.env(result, (err, window) => {
-      if (err) {
-        done(err);
-        return;
-      }
+  describe('on the client', () => {
+    it('returns nothing', (done) => {
+      jsdom.env(result, (err, window) => {
+        if (err) {
+          done(err);
+          return;
+        }
 
-      global.window = window;
-      global.document = window.document;
+        global.window = window;
+        global.document = window.document;
 
-      assert.isUndefined(renderReactWithAphroditeStatic('AC', AphroditeComponent));
+        assert.isUndefined(renderReactWithAphroditeStatic('AC', AphroditeComponent));
 
-      done();
+        done();
+      });
     });
   });
 });

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -2,7 +2,7 @@ import jsdom from 'jsdom';
 import { assert } from 'chai';
 
 import AphroditeComponent from './components/AphroditeComponent';
-import { renderReactWithAphrodite } from '../';
+import { renderReactWithAphrodite, renderReactWithAphroditeStatic } from '../';
 
 describe('aphrodite css rendering', () => {
   let result;
@@ -17,6 +17,7 @@ describe('aphrodite css rendering', () => {
     assert.isString(result);
 
     assert.ok(/style data-aphrodite/.test(result));
+    assert.ok(/Zack/.test(result));
     assert.ok(/data-aphrodite-css/.test(result));
   });
 
@@ -31,6 +32,43 @@ describe('aphrodite css rendering', () => {
       global.document = window.document;
 
       renderReactWithAphrodite('AC', AphroditeComponent);
+
+      done();
+    });
+  });
+});
+
+describe('renderReactWithAphroditeStatic', () => {
+  let result;
+  beforeEach(() => {
+    result = renderReactWithAphroditeStatic('AC', AphroditeComponent)({
+      children: ['Steven'],
+      onPress() { console.log('Clicked'); },
+    });
+  });
+
+  it('the markup looks good', () => {
+    assert.isString(result);
+
+    assert.ok(/style data-aphrodite/.test(result));
+    assert.ok(/Steven/.test(result));
+  });
+
+  it('the markup does not contain aphrodite-css info for the client', () => {
+    assert.isFalse(/data-aphrodite-css/.test(result));
+  });
+
+  it('returns nothing when used on the client', (done) => {
+    jsdom.env(result, (err, window) => {
+      if (err) {
+        done(err);
+        return;
+      }
+
+      global.window = window;
+      global.document = window.document;
+
+      assert.isUndefined(renderReactWithAphroditeStatic('AC', AphroditeComponent));
 
       done();
     });


### PR DESCRIPTION
In order to improve performance when using static-rendering (i.e., server-side only static markup with no need for client-side functionality), a static-rendering version of `renderReactWithAphrodite` is added here. It is modeled after `hypernova-react`'s static renderer: https://github.com/airbnb/hypernova-react/blob/5de9af0d49a758f5a536f1f3b273b37434e230fb/src/index.js#L29-L35