### PR TITLE
Separate server and browser code

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.3.0",
   "description": "Aphrodite bindings for Hypernova",
   "main": "lib/index.js",
+  "browser": "lib/index.browser.js",
   "scripts": {
     "prepublish": "npm run build",
     "clean": "rimraf lib coverage",

--- a/src/enhance.js
+++ b/src/enhance.js
@@ -1,0 +1,16 @@
+const config = {
+  enhancers: [], // HOCs applied to the component before render: e0(e1(e2(...en(component))))
+};
+
+export const setRenderEnhancers = (...enhancers) => {
+  // Check that all enhancers are functions
+  enhancers.forEach((enhancer, index) => {
+    if (typeof enhancer !== 'function') {
+      throw new TypeError(`enhancers passed to setRenderEnhancer should be functions: ${index}`);
+    }
+  });
+
+  config.enhancers = enhancers; // clear & set
+};
+
+export const enhance = component => config.enhancers.reduceRight((x, f) => f(x), component);

--- a/src/index.browser.js
+++ b/src/index.browser.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import hypernova, {
+  load,
+  fromScript,
+} from 'hypernova';
+import { StyleSheet } from 'aphrodite';
+
+import { setRenderEnhancers, enhance } from './enhance';
+
+export { setRenderEnhancers };
+
+const returnThrower = () => () => {
+  throw new Error('server functionality does not work in browser');
+};
+
+export const renderReactWithAphrodite = (name, component) => {
+  const enhancedComponent = enhance(component);
+
+  return hypernova({
+    server: returnThrower,
+
+    client() {
+      const classNames = fromScript({ 'aphrodite-css': name });
+      if (classNames) StyleSheet.rehydrate(classNames);
+
+      const payloads = load(name);
+      if (payloads) {
+        payloads.forEach((payload) => {
+          const { node, data } = payload;
+          if (node) {
+            const element = React.createElement(enhancedComponent, data);
+            if (ReactDOM.hydrate) {
+              ReactDOM.hydrate(element, node);
+            } else {
+              ReactDOM.render(element, node);
+            }
+          }
+        });
+      }
+
+      return component;
+    },
+  });
+};
+
+export const renderReactWithAphroditeStatic = () => hypernova({
+  server: returnThrower,
+  client() {},
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,30 +1,18 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import ReactDOMServer from 'react-dom/server';
 import hypernova, {
   serialize,
-  load,
   toScript,
-  fromScript,
 } from 'hypernova';
-import { StyleSheet, StyleSheetServer } from 'aphrodite';
+import { StyleSheetServer } from 'aphrodite';
 
-const config = {
-  enhancers: [], // HOCs applied to the component before render: e0(e1(e2(...en(component))))
+import { setRenderEnhancers, enhance } from './enhance';
+
+export { setRenderEnhancers };
+
+const thrower = () => {
+  throw new Error('client functionality does not work on server');
 };
-
-export const setRenderEnhancers = (...enhancers) => {
-  // Check that all enhancers are functions
-  enhancers.forEach((enhancer, index) => {
-    if (typeof enhancer !== 'function') {
-      throw new TypeError(`enhancers passed to setRenderEnhancer should be functions: ${index}`);
-    }
-  });
-
-  config.enhancers = enhancers; // clear & set
-};
-
-const enhance = component => config.enhancers.reduceRight((x, f) => f(x), component);
 
 export const renderReactWithAphrodite = (name, component) => {
   const enhancedComponent = enhance(component);
@@ -44,27 +32,7 @@ export const renderReactWithAphrodite = (name, component) => {
       };
     },
 
-    client() {
-      const classNames = fromScript({ 'aphrodite-css': name });
-      if (classNames) StyleSheet.rehydrate(classNames);
-
-      const payloads = load(name);
-      if (payloads) {
-        payloads.forEach((payload) => {
-          const { node, data } = payload;
-          if (node) {
-            const element = React.createElement(enhancedComponent, data);
-            if (ReactDOM.hydrate) {
-              ReactDOM.hydrate(element, node);
-            } else {
-              ReactDOM.render(element, node);
-            }
-          }
-        });
-      }
-
-      return component;
-    },
+    client: thrower,
   });
 };
 
@@ -84,6 +52,6 @@ export const renderReactWithAphroditeStatic = (name, component) => {
       };
     },
 
-    client() {},
+    client: thrower,
   });
 };

--- a/test/enhance-test.js
+++ b/test/enhance-test.js
@@ -1,0 +1,48 @@
+import { assert } from 'chai';
+
+import withHOC from './components/withHOC';
+import AphroditeComponent from './components/AphroditeComponent';
+import { setRenderEnhancers } from '../lib/enhance';
+import { renderReactWithAphrodite } from '..';
+
+describe('setRenderEnhancers', () => {
+  afterEach(() => {
+    setRenderEnhancers(); // reset
+  });
+
+  it('works with no enhancers', () => {
+    setRenderEnhancers();
+
+    const result = renderReactWithAphrodite('AC', AphroditeComponent)({});
+
+    assert.isString(result);
+  });
+
+  it('works with one enhancer', () => {
+    const enhancers = [withHOC];
+    setRenderEnhancers(...enhancers);
+
+    const result = renderReactWithAphrodite('AC', AphroditeComponent)({});
+
+    assert.isString(result);
+    assert.lengthOf(result.match(/class="hoc"/g), enhancers.length);
+  });
+
+  it('works with multiple enhancers', () => {
+    const enhancers = [withHOC, withHOC, withHOC, withHOC];
+    setRenderEnhancers(...enhancers);
+
+    const result = renderReactWithAphrodite('AC', AphroditeComponent)({});
+
+    assert.isString(result);
+    assert.lengthOf(result.match(/class="hoc"/g), enhancers.length);
+  });
+
+  it('throws when passed enhancers that are not functions', () => {
+    const goodEnhancers = [withHOC];
+    assert.doesNotThrow(setRenderEnhancers.bind(this, ...goodEnhancers), TypeError);
+
+    const badEnhancers = ['not a function'];
+    assert.throws(setRenderEnhancers.bind(this, ...badEnhancers), TypeError);
+  });
+});


### PR DESCRIPTION
While looking through some bundles built for browsers, I noticed that
this module brings in react-dom/server even though it isn't needed.
Minified, this appears to be adding ~13.5 KiB of bundle weight.

To avoid this, I split out the server and client code to separate
entrypoints, and then configured the browser field in package.json to
make the right module get used when imported.